### PR TITLE
Track balance with float

### DIFF
--- a/plugins/rrl/handler.go
+++ b/plugins/rrl/handler.go
@@ -44,7 +44,7 @@ func (rrl *RRL) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) 
 
 	// if the balance is negative, drop the response (don't write response to client)
 	if b < 0 && err == nil {
-		log.Debugf("dropped response to %v for \"%v\" %v (token='%v', balance=%v)", nw.RemoteAddr().String(), nw.Msg.Question[0].String(), dns.RcodeToString[nw.Msg.Rcode], t, b)
+		log.Debugf("dropped response to %v for \"%v\" %v (token='%v', balance=%f.1)", nw.RemoteAddr().String(), nw.Msg.Question[0].String(), dns.RcodeToString[nw.Msg.Rcode], t, b)
 		// always return success, to prevent writing of error statuses to client
 		return dns.RcodeSuccess, nil
 	}

--- a/plugins/rrl/setup.go
+++ b/plugins/rrl/setup.go
@@ -75,7 +75,7 @@ func rrlParse(c *caddy.Controller) (*RRL, error) {
 					if len(args) != 1 {
 						return nil, c.ArgErr()
 					}
-					w, err := strconv.Atoi(args[0])
+					w, err := strconv.ParseFloat(args[0], 64)
 					if err != nil {
 						return nil, c.Errf("%v invalid value. %v", c.Val(), err)
 					}
@@ -114,7 +114,7 @@ func rrlParse(c *caddy.Controller) (*RRL, error) {
 					if len(args) != 1 {
 						return nil, c.ArgErr()
 					}
-					rps, err := strconv.Atoi(args[0])
+					rps, err := strconv.ParseFloat(args[0], 64)
 					if err != nil {
 						return nil, c.Errf("%v invalid value. %v", c.Val(), err)
 					}
@@ -127,7 +127,7 @@ func rrlParse(c *caddy.Controller) (*RRL, error) {
 					if len(args) != 1 {
 						return nil, c.ArgErr()
 					}
-					rps, err := strconv.Atoi(args[0])
+					rps, err := strconv.ParseFloat(args[0], 64)
 					if err != nil {
 						return nil, c.Errf("%v invalid value. %v", c.Val(), err)
 					}
@@ -141,7 +141,7 @@ func rrlParse(c *caddy.Controller) (*RRL, error) {
 					if len(args) != 1 {
 						return nil, c.ArgErr()
 					}
-					rps, err := strconv.Atoi(args[0])
+					rps, err := strconv.ParseFloat(args[0], 64)
 					if err != nil {
 						return nil, c.Errf("%v invalid value. %v", c.Val(), err)
 					}
@@ -155,7 +155,7 @@ func rrlParse(c *caddy.Controller) (*RRL, error) {
 					if len(args) != 1 {
 						return nil, c.ArgErr()
 					}
-					rps, err := strconv.Atoi(args[0])
+					rps, err := strconv.ParseFloat(args[0], 64)
 					if err != nil {
 						return nil, c.Errf("%v invalid value. %v", c.Val(), err)
 					}
@@ -169,7 +169,7 @@ func rrlParse(c *caddy.Controller) (*RRL, error) {
 					if len(args) != 1 {
 						return nil, c.ArgErr()
 					}
-					rps, err := strconv.Atoi(args[0])
+					rps, err := strconv.ParseFloat(args[0], 64)
 					if err != nil {
 						return nil, c.Errf("%v invalid value. %v", c.Val(), err)
 					}


### PR DESCRIPTION
Track balance with float to avoid cumulative rounding error with ints.
Store allowances and window as floats so we don't need to cast back and forth between int and float in the serving path.