### PR TITLE
Corrections to key construction

### DIFF
--- a/plugins/rrl/handler.go
+++ b/plugins/rrl/handler.go
@@ -33,9 +33,7 @@ func (rrl *RRL) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) 
 
 	// get token for response and debit the balance
 	rtype := responseType(nw.Msg)
-
 	t := rrl.responseToToken(nw, rtype)
-
 	allowance := rrl.allowanceForRtype(rtype)
 	// a zero allowance indicates that no RRL should be performed for the response type, so write the response to client
 	if allowance == 0 {

--- a/plugins/rrl/handler.go
+++ b/plugins/rrl/handler.go
@@ -32,15 +32,9 @@ func (rrl *RRL) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) 
 	rcode, err = plugin.NextOrFailure(rrl.Name(), rrl.Next, ctx, nw, r)
 
 	// get token for response and debit the balance
-	// todo: roll this stuff into a single func responseToToken(nw nonwriter)
-	rtype := responseType(*nw.Msg)
-	var name string
-	if (rtype == rTypeNxdomain || rtype == rTypeReferral) && len(nw.Msg.Ns) > 0 {
-		name = nw.Msg.Ns[0].Header().Name
-	} else {
-		name = nw.Msg.Question[0].Name
-	}
-	t := rrl.responseToToken(rtype, nw.Msg.Question[0].Qtype, name, nw.RemoteAddr().String())
+	rtype := responseType(nw.Msg)
+
+	t := rrl.responseToToken(nw, rtype)
 
 	allowance := rrl.allowanceForRtype(rtype)
 	// a zero allowance indicates that no RRL should be performed for the response type, so write the response to client

--- a/plugins/rrl/rrl.go
+++ b/plugins/rrl/rrl.go
@@ -112,7 +112,7 @@ func (rrl *RRL) responseToToken(nw *nonwriter.Writer, rtype byte) string {
 
 // buildToken returns a token string for the given inputs
 func (rrl *RRL) buildToken(rtype uint8, qtype uint16, name, remoteAddr string) string {
-	// "Per BIND" references below are copied from from the BIND 9.11 Manual
+	// "Per BIND" references below are copied from the BIND 9.11 Manual
 	// https://ftp.isc.org/isc/bind9/cur/9.11/doc/arm/Bv9ARM.pdf
 	prefix := rrl.addrPrefix(remoteAddr)
 	rtypestr := strconv.FormatUint(uint64(rtype), 10)

--- a/plugins/rrl/rrl.go
+++ b/plugins/rrl/rrl.go
@@ -99,34 +99,26 @@ func (rrl *RRL) responseToToken(rtype uint8, qtype uint16, name, remoteAddr stri
 	// "Per BIND" references below are copied from from the BIND 9.11 Manual
 	// https://ftp.isc.org/isc/bind9/cur/9.11/doc/arm/Bv9ARM.pdf
 	prefix := rrl.addrPrefix(remoteAddr)
+	rtypestr := strconv.FormatUint(uint64(rtype), 10)
 	switch rtype {
 	case rTypeResponse:
 		// Per BIND: All non-empty responses for a valid domain name (qname) and record type (qtype) are identical
 		qtypeStr := strconv.FormatUint(uint64(qtype), 10)
-		rtypestr := strconv.FormatUint(uint64(rtype), 10)
 		return strings.Join([]string{prefix, rtypestr, qtypeStr, name}, "/")
 	case rTypeNodata:
 		// Per BIND: All empty (NODATA) responses for a valid domain, regardless of query type, are identical.
-		rtypestr := strconv.FormatUint(uint64(rtype), 10)
-		prefix := rrl.addrPrefix(remoteAddr)
 		return strings.Join([]string{prefix, rtypestr, "", name}, "/")
 	case rTypeNxdomain:
 		// Per BIND: Requests for any and all undefined subdomains of a given valid domain result in NXDOMAIN errors
 		// and are identical regardless of query type.
-		rtypestr := strconv.FormatUint(uint64(rtype), 10)
-		prefix := rrl.addrPrefix(remoteAddr)
 		return strings.Join([]string{prefix, rtypestr, "", name}, "/")
 	case rTypeReferral:
 		// Per BIND: Referrals or delegations to the server of a given domain are identical.
 		qtypeStr := strconv.FormatUint(uint64(qtype), 10)
-		rtypestr := strconv.FormatUint(uint64(rtype), 10)
-		prefix := rrl.addrPrefix(remoteAddr)
 		return strings.Join([]string{prefix, rtypestr, qtypeStr, name}, "/")
 	case rTypeError:
 		// Per BIND: All requests that result in DNS errors other than NXDOMAIN, such as SERVFAIL and FORMERR, are
 		// identical regardless of requested name (qname) or record type (qtype).
-		rtypestr := strconv.FormatUint(uint64(rtype), 10)
-		prefix := rrl.addrPrefix(remoteAddr)
 		return strings.Join([]string{prefix, rtypestr, "", ""}, "/")
 	}
 	return ""

--- a/plugins/rrl/rrl.go
+++ b/plugins/rrl/rrl.go
@@ -96,18 +96,40 @@ func (rrl *RRL) initTable() {
 
 // responseToToken returns a token string for the given inputs
 func (rrl *RRL) responseToToken(rtype uint8, qtype uint16, name, remoteAddr string) string {
-	var qname string
-
-	if rtype != rTypeError {
-		qname = name
-	}
-
-	qtypeStr := strconv.FormatUint(uint64(qtype), 10)
-	rtypestr := strconv.FormatUint(uint64(rtype), 10)
-
+	// "Per BIND" references below are copied from from the BIND 9.11 Manual
+	// https://ftp.isc.org/isc/bind9/cur/9.11/doc/arm/Bv9ARM.pdf
 	prefix := rrl.addrPrefix(remoteAddr)
-
-	return strings.Join([]string{prefix, rtypestr, qtypeStr, qname}, "/")
+	switch rtype {
+	case rTypeResponse:
+		// Per BIND: All non-empty responses for a valid domain name (qname) and record type (qtype) are identical
+		qtypeStr := strconv.FormatUint(uint64(qtype), 10)
+		rtypestr := strconv.FormatUint(uint64(rtype), 10)
+		return strings.Join([]string{prefix, rtypestr, qtypeStr, name}, "/")
+	case rTypeNodata:
+		// Per BIND: All empty (NODATA) responses for a valid domain, regardless of query type, are identical.
+		rtypestr := strconv.FormatUint(uint64(rtype), 10)
+		prefix := rrl.addrPrefix(remoteAddr)
+		return strings.Join([]string{prefix, rtypestr, "", name}, "/")
+	case rTypeNxdomain:
+		// Per BIND: Requests for any and all undefined subdomains of a given valid domain result in NXDOMAIN errors
+		// and are identical regardless of query type.
+		rtypestr := strconv.FormatUint(uint64(rtype), 10)
+		prefix := rrl.addrPrefix(remoteAddr)
+		return strings.Join([]string{prefix, rtypestr, "", name}, "/")
+	case rTypeReferral:
+		// Per BIND: Referrals or delegations to the server of a given domain are identical.
+		qtypeStr := strconv.FormatUint(uint64(qtype), 10)
+		rtypestr := strconv.FormatUint(uint64(rtype), 10)
+		prefix := rrl.addrPrefix(remoteAddr)
+		return strings.Join([]string{prefix, rtypestr, qtypeStr, name}, "/")
+	case rTypeError:
+		// Per BIND: All requests that result in DNS errors other than NXDOMAIN, such as SERVFAIL and FORMERR, are
+		// identical regardless of requested name (qname) or record type (qtype).
+		rtypestr := strconv.FormatUint(uint64(rtype), 10)
+		prefix := rrl.addrPrefix(remoteAddr)
+		return strings.Join([]string{prefix, rtypestr, "", ""}, "/")
+	}
+	return ""
 }
 
 // debit will decrement an existing response account in the rrl table by one and recalculate the current balance,

--- a/plugins/rrl/rrl_bench_test.go
+++ b/plugins/rrl/rrl_bench_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 )
 
-func BenchmarkResponseToToken(b *testing.B) {
+func BenchmarkBuildToken(b *testing.B) {
 	rrl := RRL{
 		ipv4PrefixLength: 24,
 		ipv6PrefixLength: 56,
@@ -17,7 +17,7 @@ func BenchmarkResponseToToken(b *testing.B) {
 	b.ReportAllocs()
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
-		rrl.responseToToken(rTypeResponse, dns.TypeA, "example.org.", "101.102.103.104:4321")
+		rrl.buildToken(rTypeResponse, dns.TypeA, "example.org.", "101.102.103.104:4321")
 	}
 }
 

--- a/plugins/rrl/rrl_test.go
+++ b/plugins/rrl/rrl_test.go
@@ -122,11 +122,32 @@ func TestResponseToToken(t *testing.T) {
 			expected:   "1.2.3.0/0/1/example.com",
 		},
 		{
+			rtype:      rTypeNodata,
+			qtype:      dns.TypeA,
+			name:       "example.com",
+			remoteAddr: "1.2.3.4:1234",
+			expected:   "1.2.3.0/1//example.com",
+		},
+		{
 			rtype:      rTypeError,
 			qtype:      dns.TypeA,
 			name:       "example.com",
 			remoteAddr: "1.2.3.4:1234",
-			expected:   "1.2.3.0/4/1/",
+			expected:   "1.2.3.0/4//",
+		},
+		{
+			rtype:      rTypeNxdomain,
+			qtype:      dns.TypeA,
+			name:       "example.com",
+			remoteAddr: "1.2.3.4:1234",
+			expected:   "1.2.3.0/2//example.com",
+		},
+		{
+			rtype:      rTypeReferral,
+			qtype:      dns.TypeA,
+			name:       "example.com",
+			remoteAddr: "1.2.3.4:1234",
+			expected:   "1.2.3.0/3/1/example.com",
 		},
 	}
 	rrl := defaultRRL()

--- a/plugins/rrl/rrl_test.go
+++ b/plugins/rrl/rrl_test.go
@@ -81,7 +81,7 @@ func TestResponseType(t *testing.T) {
 		},
 	}
 	for _, c := range tests {
-		got := responseType(c.msg)
+		got := responseType(&c.msg)
 		if got != c.expected {
 			t.Errorf("expected '%v', got '%v'", c.expected, got)
 		}
@@ -106,7 +106,7 @@ func TestAllowanceForRtype(t *testing.T) {
 	}
 }
 
-func TestResponseToToken(t *testing.T) {
+func TestBuildToken(t *testing.T) {
 	tests := []struct {
 		rtype      uint8
 		qtype      uint16
@@ -152,7 +152,7 @@ func TestResponseToToken(t *testing.T) {
 	}
 	rrl := defaultRRL()
 	for _, c := range tests {
-		got := rrl.responseToToken(c.rtype, c.qtype, c.name, c.remoteAddr)
+		got := rrl.buildToken(c.rtype, c.qtype, c.name, c.remoteAddr)
 		if got != c.expected {
 			t.Errorf("expected '%v', got '%v'", c.expected, got)
 		}


### PR DESCRIPTION
Couple of fixes:

For nxdomains and referrals only index on authoritative domain, not full qname.
For nodata, don't index on qtype.

Add more tests to cover each type.