### PR TITLE
improve rate limiting

### DIFF
--- a/plugins/rrl/handler.go
+++ b/plugins/rrl/handler.go
@@ -44,7 +44,7 @@ func (rrl *RRL) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) 
 
 	// if the balance is negative, drop the response (don't write response to client)
 	if b < 0 && err == nil {
-		log.Debugf("dropped response to %v for \"%v\" %v (token='%v', balance=%f.1)", nw.RemoteAddr().String(), nw.Msg.Question[0].String(), dns.RcodeToString[nw.Msg.Rcode], t, b)
+		log.Debugf("dropped response to %v for \"%v\" %v (token='%v', balance=%.1f)", nw.RemoteAddr().String(), nw.Msg.Question[0].String(), dns.RcodeToString[nw.Msg.Rcode], t, float64(b)/float64(allowance))
 		// always return success, to prevent writing of error statuses to client
 		return dns.RcodeSuccess, nil
 	}

--- a/plugins/rrl/handler_test.go
+++ b/plugins/rrl/handler_test.go
@@ -2,8 +2,9 @@ package rrl
 
 import (
 	"context"
-	"github.com/coredns/coredns/plugin/pkg/dnstest"
 	"testing"
+
+	"github.com/coredns/coredns/plugin/pkg/dnstest"
 
 	"github.com/coredns/coredns/plugin/test"
 	"github.com/miekg/dns"
@@ -15,8 +16,8 @@ func TestServeDNSRateLimit(t *testing.T) {
 	rrl := defaultRRL()
 	rrl.Next = test.HandlerFunc(fixedAnswer)
 	rrl.Zones = []string{"example.com."}
-	rrl.window = 2
-	rrl.responsesPerSecond = 1
+	rrl.window = 2 * second
+	rrl.responsesInterval = second
 	rrl.initTable()
 
 	ctx := context.TODO()
@@ -52,8 +53,8 @@ func TestServeDNStcp(t *testing.T) {
 	rrl := defaultRRL()
 	rrl.Next = test.HandlerFunc(fixedAnswer)
 	rrl.Zones = []string{"example.com."}
-	rrl.window = 2
-	rrl.responsesPerSecond = 1
+	rrl.window = 2 * second
+	rrl.responsesInterval = second
 	rrl.initTable()
 
 	ctx := context.TODO()
@@ -82,8 +83,8 @@ func TestServeDNSForeignZone(t *testing.T) {
 	rrl := defaultRRL()
 	rrl.Next = test.HandlerFunc(fixedAnswer)
 	rrl.Zones = []string{"not.example.com."}
-	rrl.window = 2
-	rrl.responsesPerSecond = 1
+	rrl.window = 2 * second
+	rrl.responsesInterval = second
 	rrl.initTable()
 
 	ctx := context.TODO()
@@ -111,8 +112,8 @@ func TestServeDNSZeroAllowance(t *testing.T) {
 	rrl := defaultRRL()
 	rrl.Next = test.HandlerFunc(fixedAnswer)
 	rrl.Zones = []string{"example.com."}
-	rrl.window = 2
-	rrl.responsesPerSecond = 0 // zero allowance should disable rate limiting
+	rrl.window = 2 * second
+	rrl.responsesInterval = 0 // zero allowance should disable rate limiting
 	rrl.initTable()
 
 	ctx := context.TODO()

--- a/plugins/rrl/rrl_bench_test.go
+++ b/plugins/rrl/rrl_bench_test.go
@@ -2,11 +2,12 @@ package rrl
 
 import (
 	"context"
+	"strconv"
+	"testing"
+
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/plugin/test"
 	"github.com/miekg/dns"
-	"strconv"
-	"testing"
 )
 
 func BenchmarkBuildToken(b *testing.B) {
@@ -23,9 +24,9 @@ func BenchmarkBuildToken(b *testing.B) {
 
 func BenchmarkDebit(b *testing.B) {
 	rrl := RRL{
-		window:             15,
-		responsesPerSecond: 10,
-		maxTableSize:       10000,
+		window:            15 * second,
+		responsesInterval: second / 10,
+		maxTableSize:      10000,
 	}
 	rrl.initTable()
 	b.ReportAllocs()
@@ -37,15 +38,15 @@ func BenchmarkDebit(b *testing.B) {
 
 func BenchmarkServeDNS(b *testing.B) {
 	rrl := RRL{
-		Zones:              []string{"example.org."},
-		Next:               backendHandler(),
-		window:             15,
-		ipv4PrefixLength:   24,
-		ipv6PrefixLength:   56,
-		responsesPerSecond: 10,
-		nxdomainsPerSecond: 10,
-		errorsPerSecond:    10,
-		maxTableSize:       1000,
+		Zones:             []string{"example.org."},
+		Next:              backendHandler(),
+		window:            15 * second,
+		ipv4PrefixLength:  24,
+		ipv6PrefixLength:  56,
+		responsesInterval: second / 10,
+		nxdomainsInterval: second / 10,
+		errorsInterval:    second / 10,
+		maxTableSize:      1000,
 	}
 	rrl.initTable()
 

--- a/plugins/rrl/setup_test.go
+++ b/plugins/rrl/setup_test.go
@@ -2,8 +2,9 @@ package rrl
 
 import (
 	"fmt"
-	"github.com/mholt/caddy"
 	"testing"
+
+	"github.com/mholt/caddy"
 )
 
 func TestSetupZones(t *testing.T) {
@@ -68,11 +69,11 @@ func TestSetupAllowances(t *testing.T) {
                  }`,
 			shouldErr: false,
 			expected: RRL{
-				responsesPerSecond: 10,
-				nodataPerSecond:    10,
-				nxdomainsPerSecond: 10,
-				referralsPerSecond: 10,
-				errorsPerSecond:    10,
+				responsesInterval: second / 10,
+				nodataInterval:    second / 10,
+				nxdomainsInterval: second / 10,
+				referralsInterval: second / 10,
+				errorsInterval:    second / 10,
 			},
 		},
 		{input: `rrl {
@@ -84,11 +85,11 @@ func TestSetupAllowances(t *testing.T) {
                  }`,
 			shouldErr: false,
 			expected: RRL{
-				responsesPerSecond: 10,
-				nodataPerSecond:    5,
-				nxdomainsPerSecond: 6,
-				referralsPerSecond: 7,
-				errorsPerSecond:    8,
+				responsesInterval: second / 10,
+				nodataInterval:    second / 5,
+				nxdomainsInterval: second / 6,
+				referralsInterval: second / 7,
+				errorsInterval:    second / 8,
 			},
 		},
 		{input: `rrl {
@@ -198,20 +199,20 @@ func TestSetupAllowances(t *testing.T) {
 			continue
 		}
 
-		if rrl.responsesPerSecond != test.expected.responsesPerSecond {
-			t.Errorf("Test %v: Expected responsesPerSecond %v but found: %v", i, test.expected.responsesPerSecond, rrl.responsesPerSecond)
+		if rrl.responsesInterval != test.expected.responsesInterval {
+			t.Errorf("Test %v: Expected responsesInterval %v but found: %v", i, test.expected.responsesInterval, rrl.responsesInterval)
 		}
-		if rrl.nodataPerSecond != test.expected.nodataPerSecond {
-			t.Errorf("Test %v: Expected nodataPerSecond %v but found: %v", i, test.expected.nodataPerSecond, rrl.nodataPerSecond)
+		if rrl.nodataInterval != test.expected.nodataInterval {
+			t.Errorf("Test %v: Expected nodataInterval %v but found: %v", i, test.expected.nodataInterval, rrl.nodataInterval)
 		}
-		if rrl.nxdomainsPerSecond != test.expected.nxdomainsPerSecond {
-			t.Errorf("Test %v: Expected nxdomainsPerSecond %v but found: %v", i, test.expected.nxdomainsPerSecond, rrl.nxdomainsPerSecond)
+		if rrl.nxdomainsInterval != test.expected.nxdomainsInterval {
+			t.Errorf("Test %v: Expected nxdomainsInterval %v but found: %v", i, test.expected.nxdomainsInterval, rrl.nxdomainsInterval)
 		}
-		if rrl.referralsPerSecond != test.expected.referralsPerSecond {
-			t.Errorf("Test %v: Expected referralsPerSecond %v but found: %v", i, test.expected.referralsPerSecond, rrl.referralsPerSecond)
+		if rrl.referralsInterval != test.expected.referralsInterval {
+			t.Errorf("Test %v: Expected referralsInterval %v but found: %v", i, test.expected.referralsInterval, rrl.referralsInterval)
 		}
-		if rrl.errorsPerSecond != test.expected.errorsPerSecond {
-			t.Errorf("Test %v: Expected errorsPerSecond %v but found: %v", i, test.expected.errorsPerSecond, rrl.errorsPerSecond)
+		if rrl.errorsInterval != test.expected.errorsInterval {
+			t.Errorf("Test %v: Expected errorsInterval %v but found: %v", i, test.expected.errorsInterval, rrl.errorsInterval)
 		}
 	}
 }
@@ -231,7 +232,7 @@ func TestSetupWindow(t *testing.T) {
                  }`,
 			shouldErr: false,
 			expected: RRL{
-				window: 10,
+				window: 10 * second,
 			},
 		},
 		{input: `rrl {
@@ -436,7 +437,7 @@ func TestSetupInvalidOption(t *testing.T) {
                    blah
                  }`,
 			shouldErr: true,
-			expected: RRL{},
+			expected:  RRL{},
 		},
 	}
 


### PR DESCRIPTION
 - use integers instead of floating-point numbers to make calcualtions
   more accurate

 - reduce size of ResponseAccount by storing only `allowTime` - the
   timestamp after which the next response is allowed. Balance can
   be easily calculated for given current time

 - internally, the QPS values are represented as time interval between 
   two allowed responses. This reduces computation when processing
   DNS response
