### PR TITLE
enhance benchmark

### DIFF
--- a/plugins/rrl/rrl_bench_test.go
+++ b/plugins/rrl/rrl_bench_test.go
@@ -68,10 +68,20 @@ func BenchmarkServeDNS(b *testing.B) {
 	l := len(reqs)
 	b.ReportAllocs()
 	b.StartTimer()
-	for i := 0; i < b.N; i++ {
-		rrl.ServeDNS(ctx, &test.ResponseWriter{}, reqs[j])
-		j = (j + 1) % l
-	}
+
+	b.Run("with-rrl", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			rrl.ServeDNS(ctx, &test.ResponseWriter{}, reqs[j])
+			j = (j + 1) % l
+		}
+	})
+
+	b.Run("without-rrl", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			rrl.Next.ServeDNS(ctx, &test.ResponseWriter{}, reqs[j])
+			j = (j + 1) % l
+		}
+	})
 }
 
 // backendHandler returns a response based on the first character of the qname.


### PR DESCRIPTION
 - split ServeDNS test into two subtests - with and without rrl plugin.
   This way we can figure out the share of rrl plugin activity.