### PR TITLE
Register `rrl` directive automatically

### DIFF
--- a/plugins/rrl/setup.go
+++ b/plugins/rrl/setup.go
@@ -17,6 +17,7 @@ func init() {
 		ServerType: "dns",
 		Action:     setup,
 	})
+	dnsserver.Directives = append(dnsserver.Directives, "rrl")
 }
 
 func setup(c *caddy.Controller) error {


### PR DESCRIPTION
Use Case:

To use rrl plugin from node-cache tool https://github.com/kubernetes/dns/blob/master/cmd/node-cache/main.go  

If I try to use rrl plugin from master with node-cache  it does not parse Corefile with an error "Error during parsing: Unknown directive 'rrl'"