### PR TITLE
Implement slip-ratio

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ rrl [ZONES...] {
     nxdomains-per-second ALLOWANCE
     referrals-per-second ALLOWANCE
     errors-per-second ALLOWANCE
+    slip-ratio N
     requests-per-second ALLOWANCE
     max-table-size SIZE
     report-only
@@ -73,6 +74,12 @@ rrl [ZONES...] {
 * `referrals-per-second ALLOWANCE` - the number of referral responses allowed per second. An **ALLOWANCE** of 0 disables rate limiting of referral responses. Defaults to responses-per-second.
 
 * `errors-per-second ALLOWANCE` - the number of error responses allowed per second (excluding NXDOMAIN). An **ALLOWANCE** of 0 disables rate limiting of error responses. Defaults to responses-per-second.
+
+* `slip-ratio N` - Let every **N**th dropped response slip through truncated. Responses that slip through are marked 
+  truncated and have all sections emptied before being relayed. A client receiving a truncated response will retry using TCP,
+  which is not subject to response rate limiting.  This provides a way for clients making legitimate requests to get an 
+  answer while their IP prefix is being blocked by response rate limiting. For **N** = 1 slip every dropped response through;
+  **N** = 4 slip every 4th dropped response through; etc. The default is **N** = 0, don't slip any responses through.
 
 * `requests-per-second ALLOWANCE` - the number of requests allowed per second. An **ALLOWANCE** of 0 disables rate limiting of requests. Default 0.
 

--- a/plugins/rrl/handler_test.go
+++ b/plugins/rrl/handler_test.go
@@ -6,8 +6,9 @@ import (
 
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
 
-	"github.com/coredns/coredns/plugin/test"
 	"github.com/miekg/dns"
+
+	"github.com/coredns/coredns/plugin/test"
 )
 
 func TestServeDNSRateLimit(t *testing.T) {
@@ -134,6 +135,71 @@ func TestServeDNSZeroAllowance(t *testing.T) {
 		t.Errorf("expected message to be written to client")
 	}
 
+}
+
+func TestServeDNSRateLimitSlips(t *testing.T) {
+	t.Run("0", func(t *testing.T) {
+		testServeDNSRateLimitSlip(t, 0, 0)
+	})
+	t.Run("1", func(t *testing.T) {
+		testServeDNSRateLimitSlip(t, 1, 10)
+	})
+	t.Run("2", func(t *testing.T) {
+		testServeDNSRateLimitSlip(t, 2, 5)
+	})
+	t.Run("5", func(t *testing.T) {
+		testServeDNSRateLimitSlip(t, 5, 2)
+	})
+	t.Run("10", func(t *testing.T) {
+		testServeDNSRateLimitSlip(t, 10, 1)
+	})
+}
+
+func testServeDNSRateLimitSlip(t *testing.T, slipRatio uint, expectedSlips int) {
+	tc := test.Case{Qname: "example.com", Qtype: dns.TypeA, Rcode: dns.RcodeSuccess}
+
+	rrl := defaultRRL()
+	rrl.Next = test.HandlerFunc(fixedAnswer)
+	rrl.Zones = []string{"example.com."}
+	rrl.window = 2 * second
+	rrl.responsesInterval = second
+	rrl.slipRatio = slipRatio
+	rrl.initTable()
+
+	ctx := context.TODO()
+
+	w := dnstest.NewRecorder(&test.ResponseWriter{})
+	_, err := rrl.ServeDNS(ctx, w, tc.Msg())
+	if err != nil {
+		t.Errorf("expected no error, got: %v", err)
+	}
+	// ensure that the message was written to the client
+	if w.Len == 0 {
+		t.Errorf("expected message to be written to client")
+	}
+
+	var responses []*dns.Msg
+	for i := 0; i < 10; i++ {
+		w = dnstest.NewRecorder(&test.ResponseWriter{})
+		rrl.ServeDNS(ctx, w, tc.Msg())
+		if w.Msg == nil {
+			continue
+		}
+		responses = append(responses, w.Msg)
+	}
+
+	for _, r := range responses {
+		if !r.Truncated {
+			t.Errorf("Slipped message not marked truncated")
+		}
+		if len(r.Answer) != 0 {
+			t.Errorf("Slipped message Answer section is not empty")
+		}
+	}
+
+	if len(responses) != expectedSlips {
+		t.Errorf("expected %v messages to slip, got %v", expectedSlips, len(responses))
+	}
 }
 
 func fixedAnswer(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {

--- a/plugins/rrl/rrl_test.go
+++ b/plugins/rrl/rrl_test.go
@@ -6,8 +6,9 @@ import (
 
 	"github.com/coredns/rrl/plugins/rrl/cache"
 
-	"github.com/coredns/coredns/plugin/test"
 	"github.com/miekg/dns"
+
+	"github.com/coredns/coredns/plugin/test"
 )
 
 func TestDebit(t *testing.T) {
@@ -18,28 +19,28 @@ func TestDebit(t *testing.T) {
 	rrl.nxdomainsInterval = second / 100
 	rrl.table = cache.New(rrl.maxTableSize)
 
-	_, err := rrl.debit(rrl.allowanceForRtype(rTypeResponse), "token1")
+	_, _, err := rrl.debit(rrl.allowanceForRtype(rTypeResponse), "token1")
 	if err != nil {
 		t.Errorf("got error: %v", err)
 	}
 	ra, _ := rrl.table.Get("token1")
 	bal := time.Now().UnixNano() - ra.(*ResponseAccount).allowTime
-	if bal < second - rrl.responsesInterval {
-		t.Errorf("expected balance not less than %v, got %v", second - rrl.responsesInterval, bal)
+	if bal < second-rrl.responsesInterval {
+		t.Errorf("expected balance not less than %v, got %v", second-rrl.responsesInterval, bal)
 	}
 
-	bal, err = rrl.debit(rrl.allowanceForRtype(rTypeResponse), "token1")
-	if bal > second - rrl.responsesInterval {
-		t.Errorf("expected balance of < %v, got %v", second - rrl.responsesInterval, bal)
+	bal, _, err = rrl.debit(rrl.allowanceForRtype(rTypeResponse), "token1")
+	if bal > second-rrl.responsesInterval {
+		t.Errorf("expected balance of < %v, got %v", second-rrl.responsesInterval, bal)
 	}
 
-	_, err = rrl.debit(rrl.allowanceForRtype(rTypeNxdomain), "token2")
+	_, _, err = rrl.debit(rrl.allowanceForRtype(rTypeNxdomain), "token2")
 	if err != nil {
 		t.Errorf("got error: %v", err)
 	}
 	time.Sleep(time.Second) // sleep 1 second, balance should max out
-	bal, err = rrl.debit(rrl.allowanceForRtype(rTypeNxdomain), "token2")
-	if bal != second - rrl.nxdomainsInterval {
+	bal, _, err = rrl.debit(rrl.allowanceForRtype(rTypeNxdomain), "token2")
+	if bal != second-rrl.nxdomainsInterval {
 		t.Errorf("expected balance of %v, got %v", rrl.window-rrl.nxdomainsInterval, bal)
 	}
 

--- a/plugins/rrl/setup.go
+++ b/plugins/rrl/setup.go
@@ -130,6 +130,19 @@ func rrlParse(c *caddy.Controller) (*RRL, error) {
 					}
 					rrl.errorsInterval = i
 					errorsIntervalSet = true
+				case "slip-ratio":
+					args := c.RemainingArgs()
+					if len(args) != 1 {
+						return nil, c.ArgErr()
+					}
+					i, err := strconv.Atoi(c.Val())
+					if err != nil {
+						return nil, c.Errf("slip-ratio '%v' invalid value. %v", c.Val(), err)
+					}
+					if i < 0 || i > 10 {
+						return nil, c.Errf("slip-ratio '%v' must be between 0 and 10", c.Val())
+					}
+					rrl.slipRatio = uint(i)
 				case "requests-per-second":
 					i, err := getIntervalArg(c)
 					if err != nil {

--- a/plugins/rrl/setup_test.go
+++ b/plugins/rrl/setup_test.go
@@ -429,6 +429,69 @@ func TestSetupTableSize(t *testing.T) {
 	}
 }
 
+func TestSetupSlipRatio(t *testing.T) {
+	tests := []struct {
+		input     string
+		shouldErr bool
+		expected  RRL
+	}{
+		{input: `rrl`,
+			shouldErr: false,
+			expected:  defaultRRL(),
+		},
+		{input: `rrl {
+                   slip-ratio 5
+                 }`,
+			shouldErr: false,
+			expected:  RRL{slipRatio: 5},
+		},
+		{input: `rrl {
+                   slip-ratio -1
+                 }`,
+			shouldErr: true,
+			expected:  RRL{},
+		},
+		{input: `rrl {
+                   slip-ratio 2 3
+                 }`,
+			shouldErr: true,
+			expected:  RRL{},
+		},
+		{input: `rrl {
+                   slip-ratio nine
+                 }`,
+			shouldErr: true,
+			expected:  RRL{},
+		},
+		{input: `rrl {
+                   slip-ratio
+                 }`,
+			shouldErr: true,
+			expected:  RRL{},
+		},
+	}
+
+	for i, test := range tests {
+		c := caddy.NewTestController("dns", test.input)
+		rrl, err := rrlParse(c)
+
+		if test.shouldErr && err == nil {
+			t.Errorf("Test %v: Expected error but found nil", i)
+			continue
+		} else if !test.shouldErr && err != nil {
+			t.Errorf("Test %v: Expected no error but found error: %v", i, err)
+			continue
+		}
+		if test.shouldErr && err != nil {
+			continue
+		}
+
+		if rrl.slipRatio != test.expected.slipRatio {
+			t.Errorf("Test %v: Expected slipRatio %v but found: %v", i, test.expected.slipRatio, rrl.slipRatio)
+		}
+	}
+}
+
 func TestSetupInvalidOption(t *testing.T) {
 	tests := []struct {
 		input     string


### PR DESCRIPTION
This is a rather literal implementation of `slip-ratio` as documented by BIND Response Rate Limiting.  It tracks the number of times each response category would be blocked and lets every nth item through as a truncated response to induce a TCP retry on client.

A looser, and possibly slightly more efficient alternate approach could be to let requests through based on weighted random number rather than tracking the actual number of times a response category is blocked - e.g. `slip-ratio 4` would allow 25% of blocked responses through, instead of every 4th blocked response. 

closes #32

Signed-off-by: Chris O'Haver <cohaver@infoblox.com>