### PR TITLE
fix: rrl eviction function and deadlock on eviction failure

### DIFF
--- a/plugins/rrl/cache/cache_test.go
+++ b/plugins/rrl/cache/cache_test.go
@@ -20,15 +20,16 @@ func TestCacheAddGetRemove(t *testing.T) {
 func TestCacheUpdateAdd(t *testing.T) {
 	c := New(4)
 
-	updateFunc := func(el *interface{}) interface{} {
-		i := (*el).(int)
-		i += 1
-		*el = i
-		return i
+	updateFunc := func(el interface{}) interface{} {
+		iptr := el.(*int)
+		*iptr += 1
+		el = iptr
+		return iptr
 	}
 
 	addFunc := func() interface{} {
-		return 1
+		i := 1
+		return &i
 	}
 
 	// first call should insert value returned by add
@@ -38,7 +39,7 @@ func TestCacheUpdateAdd(t *testing.T) {
 	if !found {
 		t.Fatal("failed to find inserted record")
 	}
-	i := (el).(int)
+	i := *(el.(*int))
 	if i != 1 {
 		t.Fatalf("expected to see inital value of 1, got %v", i)
 	}
@@ -46,7 +47,7 @@ func TestCacheUpdateAdd(t *testing.T) {
 	// second call should increment the value, and return it
 	el = c.UpdateAdd("a", updateFunc, addFunc)
 
-	i = (el).(int)
+	i = *(el.(*int))
 
 	if i != 2 {
 		t.Fatalf("expected to see return value of 2, got %v", i)
@@ -55,7 +56,7 @@ func TestCacheUpdateAdd(t *testing.T) {
 	if !found {
 		t.Fatal("failed to find inserted record")
 	}
-	i = (el).(int)
+	i = *(el.(*int))
 	if i != 2 {
 		t.Fatalf("expected to see value incremented to 2, got %v", i)
 	}

--- a/plugins/rrl/cache/shard_test.go
+++ b/plugins/rrl/cache/shard_test.go
@@ -62,15 +62,16 @@ func TestShardLenEvict(t *testing.T) {
 func TestShardUpdateAdd(t *testing.T) {
 	s := newShard(1)
 
-	updateFunc := func(el *interface{}) interface{} {
-		i := (*el).(int)
-		i += 1
-		*el = i
-		return i
+	updateFunc := func(el interface{}) interface{} {
+		iptr := el.(*int)
+		*iptr += 1
+		el = iptr
+		return iptr
 	}
 
 	addFunc := func() interface{} {
-		return 1
+		i := 1
+		return &i
 	}
 
 	// first call should insert value returned by add
@@ -80,25 +81,25 @@ func TestShardUpdateAdd(t *testing.T) {
 	if !found {
 		t.Fatal("failed to find inserted record")
 	}
-	i := (el).(int)
-	if i != 1 {
-		t.Fatalf("expected to see inital valie of 1, got %v", i)
+	i := el.(*int)
+	if *i != 1 {
+		t.Fatalf("expected to see inital value of 1, got %v", *i)
 	}
 
 	// second call should increment the value, and return it
 	el = s.UpdateAdd("a", updateFunc, addFunc)
 
-	i = (el).(int)
+	i = el.(*int)
 
-	if i != 2 {
+	if *i != 2 {
 		t.Fatalf("expected to see return value of 2, got %v", i)
 	}
 	el, found = s.Get("a")
 	if !found {
 		t.Fatal("failed to find inserted record")
 	}
-	i = (el).(int)
-	if i != 2 {
+	i = el.(*int)
+	if *i != 2 {
 		t.Fatalf("expected to see value incremented to 2, got %v", i)
 	}
 

--- a/plugins/rrl/rrl.go
+++ b/plugins/rrl/rrl.go
@@ -96,8 +96,8 @@ func (rrl *RRL) allowanceForRtype(rtype uint8) int64 {
 func (rrl *RRL) initTable() {
 	rrl.table = cache.New(rrl.maxTableSize)
 	// This eviction function returns true if the allowance is >= max value (window)
-	rrl.table.SetEvict(func(el *interface{}) bool {
-		ra, ok := (*el).(ResponseAccount)
+	rrl.table.SetEvict(func(el interface{}) bool {
+		ra, ok := el.(*ResponseAccount)
 		if !ok {
 			return true
 		}
@@ -165,11 +165,11 @@ func (rrl *RRL) debit(allowance int64, t string) (int64, bool, error) {
 	}
 	result := rrl.table.UpdateAdd(t,
 		// the 'update' function updates the account and returns the new balance
-		func(el *interface{}) interface{} {
-			ra := (*el).(*ResponseAccount)
-			if ra == nil {
+		func(el interface{}) interface{} {
+			if el == nil {
 				return nil
 			}
+			ra := el.(*ResponseAccount)
 			now := time.Now().UnixNano()
 			balance := now - ra.allowTime - allowance
 			if balance >= second {


### PR DESCRIPTION
Fixes the rrl cache eviction function (#37) and the deadlock on eviction failure (#36)

Also refactor shard item type from `*interface{}` to `interface{}` and fix unit tests that depended on it.

Signed-off-by: Chris O'Haver <cohaver@infoblox.com>