### PR TITLE
handle edge case when there was error, but response was written

### DIFF
--- a/plugins/rrl/handler.go
+++ b/plugins/rrl/handler.go
@@ -48,7 +48,7 @@ func (rrl *RRL) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) 
 	// create a non-writer, because we need to look at the response before writing to the client
 	nw := nonwriter.New(w)
 	rcode, err := plugin.NextOrFailure(rrl.Name(), rrl.Next, ctx, nw, r)
-	if err != nil || nw.Msg == nil {
+	if !plugin.ClientWrite(rcode) {
 		return rcode, err
 	}
 


### PR DESCRIPTION
Hello, when `rrl` plugin is combined with `rewrite` plugin and upstream resolution fails, then `rrl` does not propagate [rewritten response to the other plugins](https://github.com/coredns/coredns/pull/5150), for example `prometheus` plugin.

Actual impact can be observed using this example Corefile
```
.:53 {
  rewrite edns0 local set 0xffee {client_ip}
  log
  prometheus
  forward . 1.2.3.4
  rrl . {
      ipv4-prefix-length 32
      ipv6-prefix-length 128
      requests-per-second 1000
    }
}
```

then send a DNS query
```
dig @127.0.0.1 google.com
```
this returns
```
;; communications error to 127.0.0.1#53: timed out
;; communications error to 127.0.0.1#53: timed out
```

then observe metrics
```
curl localhost:9153/metrics | grep coredns_dns_responses_total
```

you will see, that failures are measured as NOERRORs instead of failures (SERVFAIL)
```
# HELP coredns_dns_responses_total Counter of response status codes.
# TYPE coredns_dns_responses_total counter
coredns_dns_responses_total{plugin="",rcode="NOERROR",server="dns://:53",view="",zone="."} 9
```

This PR adjusts the condition for checking whether the response was written in order to propagate error responses through plugin chain properly